### PR TITLE
hotfix: maxContentWidth spelling 오류 누락 수정

### DIFF
--- a/src/pages/Profile/bookmark/index.scss
+++ b/src/pages/Profile/bookmark/index.scss
@@ -9,6 +9,6 @@
     &-container{
         align-self: center;
         width: 100%;
-        max-width: $maxContentWitdh;
+        max-width: $maxContentWidth;
     }
 }


### PR DESCRIPTION
- develop 브랜치에 머지하는 과정에서 maxContentWidth spelling 오류를 수정한 부분 중 누락된 부분이 발생해 수정했습니다. 이 부분 수정하지 않으면 website crash가 발생해 다른 분들 approve 없이 급하게 머지하는 점 이해해주시면 감사드리겠습니다 🙏 