### PR TITLE
feat: jotai 적용

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "@testing-library/user-event": "^12.1.10",
     "axios": "0.21.1",
     "factory.ts": "^0.5.2",
+    "jotai": "^1.5.3",
     "moment": "^2.29.1",
     "patch-package": "^6.4.7",
     "postinstall-postinstall": "^2.1.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,11 +1,13 @@
 import React from 'react';
 import { BrowserRouter as Router, Switch, Route, Redirect } from 'react-router-dom';
+import { useAtom } from 'jotai';
 import './App.scss';
 import { Footer, Header } from './app/shared/components';
 import LoginPage from './pages/Login';
 import ProfilePage from './pages/Profile';
 import StudyPage from './pages/Study';
 import StudyDetailPage from './pages/StudyDetail';
+import globalState from './state';
 
 const MainContainer = (): JSX.Element => (
 	<div className="router-con">
@@ -22,6 +24,15 @@ const MainContainer = (): JSX.Element => (
 );
 
 const App = (): JSX.Element => {
+	// 만약 globalState 에 저장되어 있는 값을 변경하고 싶으면
+	// const [state, setState] = useAtom(globalState);
+	// 위 코드에서 setState 로 변경할 수 있다.
+	const [state] = useAtom(globalState);
+	if (state.login) {
+		console.info('login');
+	} else {
+		console.info('not login');
+	}
 	return (
 		<Router>
 			<Header />

--- a/src/state.ts
+++ b/src/state.ts
@@ -1,0 +1,11 @@
+import { atom } from 'jotai';
+
+interface IGlobalStateProps {
+	login: boolean;
+}
+
+const globalState = atom({
+	login: !!localStorage.getItem('token'),
+} as IGlobalStateProps);
+
+export default globalState;

--- a/yarn.lock
+++ b/yarn.lock
@@ -7000,6 +7000,11 @@ jest@26.6.0:
     import-local "^3.0.2"
     jest-cli "^26.6.0"
 
+jotai@^1.5.3:
+  version "1.5.3"
+  resolved "https://registry.yarnpkg.com/jotai/-/jotai-1.5.3.tgz#0157f962c6cd7d28389f9606a1eefebf223801ed"
+  integrity sha512-iD8MkbehxTjfRUtIJJdyQcjbAe2MqjW1+oFc5lvfgRjLHwjRQyWnZC3gdGAOQCOqUSPZHOBGgWyP/8gBDckaNQ==
+
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"


### PR DESCRIPTION
state.ts - 전역 상태의 초기값이 저장되는 파일 

사용 예시를 위해 샘플 코드를 작성한 PR 입니다. 
어플리케이션 전체에서 관리할 만한 전역 상태가 어떤게 있을지 고민하다가, 로그인 여부를 불리언 값으로 관리하도록 했습니다. 
(로그인이 되어있는 경우 브라우저의 로컬 스토리지에 키가 'token' 인 데이터가 저장되어 있다고 가정했습니다.)

state.ts 파일에 login 이라는 상태를 초기화하고, 로컬 스토리지에 키가 'token' 인 데이터 존재 여부를 불리언 값으로 저장했습니다. 
그리고 App.tsx 파일에는 저장되어 있는 전역 상태를 어떻게 사용하는지 예시를 작성했습니다. 
제가 작성한 샘플 코드에서는 전역 상태를 단순히 참조만 하고 있는데, 전역 상태를 갱신하려고 하는 경우를 위해 주석을 작성해 두었습니다. 

이 샘플 코드는 어플리케이션 전체에서 관리할 전역 상태가 생기는 경우, 코드를 작성하시는 분이 주석 및 샘플 코드를 제거해주시면 됩니다 :D 