### PR TITLE
fix: 상위 카테고리가 전체 선택일 때 및 공모전일 때 하위 카테고리 바 숨김

### DIFF
--- a/src/pages/study/index.tsx
+++ b/src/pages/study/index.tsx
@@ -22,7 +22,7 @@ const StudyPage = (): JSX.Element => {
 	return (
 		<div className="studyPage-con">
 			<MainCategoryContainer onChange={setMainCategory} />
-			<SubCategoryContainer mainCategory={mainCategory} />
+			{mainCategory && !!mainCategory.subCategories.length && <SubCategoryContainer mainCategory={mainCategory} />}
 			<StudyCreateButton onClick={onClickCreate} />
 			<StudySortFilterContainer />
 			<StudyListContainter />


### PR DESCRIPTION
스터디 목록 페이지의 상위 카테고리가 전체 선택일 때 및 공모전일 때 하위 카테고리 바 보이지 않도록 수정했습니다. 