### PR TITLE
refactor: useQuery 키 enum 으로 관리하도록 개선

### DIFF
--- a/src/hooks/remotes/index.ts
+++ b/src/hooks/remotes/index.ts
@@ -1,0 +1,10 @@
+enum QUERY_KEY {
+	FETCH_STUDIES = 'fetchStudies',
+	FETCH_STUDY = 'fetchStudy',
+	FETCH_NOTICES = 'fetchNotices',
+	FETCH_NOTICE = 'fetchNotice',
+	FETCH_STUDY_USERS = 'fetchStudyUsers',
+	FETCH_USER_PROFILE = 'fetchUserProfile',
+}
+
+export default QUERY_KEY;

--- a/src/hooks/remotes/notice/useFetchNotice.ts
+++ b/src/hooks/remotes/notice/useFetchNotice.ts
@@ -1,13 +1,14 @@
 import API from '@src/api';
 import { getNoticeInterface } from '@src/api/response/notice';
 import { useQuery } from 'react-query';
+import QUERY_KEY from '@src/hooks/remotes';
 
 export default (id: string) => {
 	const fetcher = async (): Promise<getNoticeInterface> => {
 		const res = await API.getNotice(id);
 		return res.data;
 	};
-	return useQuery(`fetchNotice/${id}`, fetcher, {
+	return useQuery(`${QUERY_KEY.FETCH_NOTICE}/${id}`, fetcher, {
 		onError: (e) => {
 			console.log(e);
 		},

--- a/src/hooks/remotes/notice/useFetchNotices.ts
+++ b/src/hooks/remotes/notice/useFetchNotices.ts
@@ -1,13 +1,14 @@
 import API from '@src/api';
 import { getNoticeInterface } from '@src/api/response/notice';
 import { useQuery } from 'react-query';
+import QUERY_KEY from '@src/hooks/remotes';
 
 export default () => {
 	const fetcher = async (): Promise<getNoticeInterface[]> => {
 		const res = await API.getNotices();
 		return res.data;
 	};
-	return useQuery('fetchNotices', fetcher, {
+	return useQuery(QUERY_KEY.FETCH_NOTICES, fetcher, {
 		onError: (e) => {
 			console.log(e);
 		},

--- a/src/hooks/remotes/study/useFetchStudies.ts
+++ b/src/hooks/remotes/study/useFetchStudies.ts
@@ -1,6 +1,7 @@
 import { useQuery } from 'react-query';
 import API from '@src/api';
 import { IResponseGetStudies } from '@api/response/study';
+import QUERY_KEY from '@src/hooks/remotes';
 
 // TODO
 // parameter
@@ -10,7 +11,7 @@ export default () => {
 		return res.data;
 	};
 
-	return useQuery('fetchStudies', fetcher, {
+	return useQuery(QUERY_KEY.FETCH_STUDIES, fetcher, {
 		onError: (e) => {
 			console.log(e);
 		},

--- a/src/hooks/remotes/study/useFetchStudy.ts
+++ b/src/hooks/remotes/study/useFetchStudy.ts
@@ -1,6 +1,7 @@
 import { useQuery } from 'react-query';
 import API from '@src/api';
 import { IResponseGetStudy } from '@api/response/study';
+import QUERY_KEY from '@src/hooks/remotes';
 
 export default (id: string) => {
 	const fetcher = async (): Promise<IResponseGetStudy> => {
@@ -8,7 +9,7 @@ export default (id: string) => {
 		return res.data;
 	};
 
-	return useQuery(`fetchStudy/${id}`, fetcher, {
+	return useQuery(`${QUERY_KEY.FETCH_STUDY}/${id}`, fetcher, {
 		onError: (e) => {
 			console.log(e);
 		},

--- a/src/hooks/remotes/studyUser/useFetchStudyUsers.ts
+++ b/src/hooks/remotes/studyUser/useFetchStudyUsers.ts
@@ -1,6 +1,7 @@
 import { useQuery } from 'react-query';
 import API from '@src/api';
 import { IResponseGetStudyUsers } from '@api/response/study';
+import QUERY_KEY from '@src/hooks/remotes';
 
 export default (id: string) => {
 	const fetcher = async (): Promise<IResponseGetStudyUsers> => {
@@ -8,7 +9,7 @@ export default (id: string) => {
 		return res.data;
 	};
 
-	return useQuery(`fetchStudyUsers/${id}`, fetcher, {
+	return useQuery(`${QUERY_KEY.FETCH_STUDY_USERS}/${id}`, fetcher, {
 		onError: (e) => {
 			console.log(e);
 		},

--- a/src/hooks/remotes/user/useFetchUserProfile.ts
+++ b/src/hooks/remotes/user/useFetchUserProfile.ts
@@ -1,13 +1,14 @@
 import API from '@src/api';
 import { IResponseGetUserProfile } from '@src/api/response/user';
 import { useQuery } from 'react-query';
+import QUERY_KEY from '@src/hooks/remotes';
 
 export default (id: string) => {
 	const fetcher = async (): Promise<IResponseGetUserProfile> => {
 		const res = await API.getUserProfile(id);
 		return res.data;
 	};
-	return useQuery(`fetchUserProfile/${id}`, fetcher, {
+	return useQuery(`${QUERY_KEY.FETCH_USER_PROFILE}/${id}`, fetcher, {
 		onError: (e) => {
 			console.log(e);
 		},


### PR DESCRIPTION
useQuery 에서 사용하는 fetch query key 를 관리하는 파일을 만들고, enum 으로 관리하도록 개선했습니다. 
아직 연동된 API 가 많지 않지만, 점점 많아지면 중복되지 않게 키를 관리하기도 어렵고 일관적으로 키를 작성하기도 어려울 것 같아서 개선했다고 봐주시면 됩니다! 