### PR TITLE
fix: shortUserAbout 필드 삭제

### DIFF
--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -54,9 +54,8 @@ export interface UserProfile {
 	showAbout: boolean;
 	links: string[];
 	onBreak: boolean;
-	shortUserAbout: string;
 	categories: string[];
-	// Todo: 유저 프로필 사진, 로그인 id, 유저 카테고리, 한 줄 소개평
+	// Todo: 유저 프로필 사진
 }
 
 export interface User {

--- a/src/app/modal/UserProfileModal.tsx
+++ b/src/app/modal/UserProfileModal.tsx
@@ -43,14 +43,14 @@ const UserProfileModal = ({ open, onClose, params }: UserProfileModalProps): JSX
 				style={{ height: isPopup ? 'auto' : bottomSheetHeight }}
 				onScroll={handleScroll}
 			>
-				<div className="profile-bottom-sheet-top-short-about">{userProfile?.shortUserAbout}</div>
+				<div className="profile-bottom-sheet-top-short-about">{userProfile?.bio}</div>
 				<img
 					className={`profile-bottom-sheet-profile-img${isPopup ? '-popup' : ''}`}
 					src={sampleImgUrl}
 					alt="프로필 이미지"
 				/>
 				<div className="profile-bottom-sheet-name">{userProfile?.userName}</div>
-				<div className="profile-bottom-sheet-short-about">{userProfile?.shortUserAbout}</div>
+				<div className="profile-bottom-sheet-short-about">{userProfile?.bio}</div>
 				<div className="profile-bottom-sheet-tag-container">
 					{userProfile?.categories?.map((tagItem, tagIndex) => (
 						<div key={tagItem} className={`profile-bottom-sheet-tag-item ${tagIndex === 0 ? '' : 'ml12'}`}>

--- a/src/app/profile/interface/interface.ts
+++ b/src/app/profile/interface/interface.ts
@@ -55,7 +55,6 @@ export interface UserInfoInterface {
 	grade: number;
 	bio: string;
 	userAbout: string;
-    shortUserAbout: string;
 	links: string[];
 	status: string;
 }

--- a/src/app/profile/myProfileEdit/MyProfileEditContainer.tsx
+++ b/src/app/profile/myProfileEdit/MyProfileEditContainer.tsx
@@ -28,7 +28,7 @@ const MyProfileEditContainer = (): JSX.Element => {
 							grade={Number(userProfile.grade)}
 							onBreak={userProfile.onBreak}
 							categories={userProfile.categories}
-							shortIntro={userProfile.shortUserAbout}
+							shortIntro={userProfile.bio}
 							urls={userProfile.links.reduce((acc, linkItem, linkIdx) => {
 								if (linkItem) {
 									return [

--- a/src/app/profile/myProfileEdit/MyProfileEditPresenter.tsx
+++ b/src/app/profile/myProfileEdit/MyProfileEditPresenter.tsx
@@ -63,7 +63,7 @@ const MyProfileEditPresenter = ({
 			dept: currentMajor,
 			grade: String(currentGrade),
 			onBreak: currentOnBreak,
-			shortUserAbout: currentShortIntro,
+			bio: currentShortIntro,
 			links: filteredArray,
 			userAbout: currentLongIntro,
 		});


### PR DESCRIPTION
- 유저 프로필에서 shortUserAbout과 bio는 둘 다 짧은 소개글 필드로 중복이 됩니다.
- 따라서 shortUserAbout을 삭제하고 백엔드에서도 이 필드를 삭제하였습니다.
- https://github.com/caulipse/caulipse-server/pull/55
