### PR TITLE
fix: 북마크 페이지에서 chevron 아이콘이 거꾸로 적용되어 있었던 오류 수정

### DIFF
--- a/src/app/profile/bookmark/BookmarkPresenter.tsx
+++ b/src/app/profile/bookmark/BookmarkPresenter.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import BookmarkList from '@src/app/profile/bookmark/bookmarkList';
 import EmptyComponent from '@src/app/shared/components/emptyComponents';
-import { IoChevronDown, IoChevronUp } from 'react-icons/io5';
+import { IoChevronDown } from 'react-icons/io5';
 import './index.scss';
 import { Study } from '@src/api/types';
 
@@ -39,7 +39,7 @@ const BookmarkPresenter = ({ recruitingBookmarks, recruitedBookmarks }: Bookmark
 				{recruitedStudiesVisible || (
 					<>
 						<div>마감된 항목</div>
-						<IoChevronUp className="bookmark-chevron-icon" />
+						<IoChevronDown className="bookmark-chevron-icon" />
 					</>
 				)}
 			</button>


### PR DESCRIPTION
- 북마크 페이지 > chevron 아이콘이 거꾸로 적용되어 있어서 아래와 같이 수정했습니다.

![image](https://user-images.githubusercontent.com/59302192/158627497-fa356f9d-d7a8-4312-ae12-eecd9db8fc71.png)
