### PR TITLE
feat: 스터디 목록 조회 정렬 & 필터링 적용 

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -54,27 +54,16 @@ const API = {
 	},
 	// 스터디 목록 조회
 	getStudies(orderBy?: string, filter?: IFilterOption) {
-		// TODO parameters
-		let url = '/study';
-		if (orderBy) {
-			url += `?order_by=${orderBy}`;
-		}
-		if (filter?.frequency?.length) {
-			// FIXME
-			// 멀티 필터 가능하도록 수정
-			url += `&frequency=${filter?.frequency?.[0]}`;
-		}
-		if (filter?.location?.length) {
-			// FIXME
-			// 멀티 필터 가능하도록 수정
-			url += `&location=${filter?.location?.[0]}`;
-		}
-		if (filter?.weekday?.length) {
-			// FIXME
-			// 멀티 필터 가능하도록 수정
-			url += `&weekday=${filter?.weekday?.[0]}`;
-		}
-		return client.get(url);
+		// FIXME
+		// 멀티 필터 가능하도록 수정
+		return client.get('/study', {
+			params: {
+				order_by: orderBy,
+				frequency: filter?.frequency?.[0],
+				location: filter?.location?.[0],
+				weekday: filter?.weekday?.[0],
+			},
+		});
 	},
 	// 새로운 스터디 생성
 	postStudy(request: IRequestPostStudy) {

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -52,9 +52,13 @@ const API = {
 		return client.delete(`/study/${id}/comment/${commentId}/metoo`);
 	},
 	// 스터디 목록 조회
-	getStudies() {
+	getStudies(orderBy?: string) {
 		// TODO parameters
-		return client.get(`/study`);
+		let url = '/study';
+		if (orderBy) {
+			url += `?order_by=${orderBy}`;
+		}
+		return client.get(url);
 	},
 	// 새로운 스터디 생성
 	postStudy(request: IRequestPostStudy) {

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,5 +1,6 @@
 import axios from 'axios';
 import config from '@src/config';
+import { IFilterOption } from '@src/app/study/types';
 import { IRequestLogin, IRequestSignUp, IRequestPatchUser } from './request/user';
 import { IRequestPostUserProfile, IRequestPatchUserProfile } from './request/userProfile';
 import { IRequestPostStudy, IRequestPatchStudy } from './request/study';
@@ -52,11 +53,26 @@ const API = {
 		return client.delete(`/study/${id}/comment/${commentId}/metoo`);
 	},
 	// 스터디 목록 조회
-	getStudies(orderBy?: string) {
+	getStudies(orderBy?: string, filter?: IFilterOption) {
 		// TODO parameters
 		let url = '/study';
 		if (orderBy) {
 			url += `?order_by=${orderBy}`;
+		}
+		if (filter?.frequency?.length) {
+			// FIXME
+			// 멀티 필터 가능하도록 수정
+			url += `&frequency=${filter?.frequency?.[0]}`;
+		}
+		if (filter?.location?.length) {
+			// FIXME
+			// 멀티 필터 가능하도록 수정
+			url += `&location=${filter?.location?.[0]}`;
+		}
+		if (filter?.weekday?.length) {
+			// FIXME
+			// 멀티 필터 가능하도록 수정
+			url += `&weekday=${filter?.weekday?.[0]}`;
 		}
 		return client.get(url);
 	},

--- a/src/app/main/desktop/list/DesktopMainPageStudyList.tsx
+++ b/src/app/main/desktop/list/DesktopMainPageStudyList.tsx
@@ -8,7 +8,7 @@ import { Study } from '@api/types';
 import './index.scss';
 
 const DesktopMainPageStudyList = (): JSX.Element => {
-	const { data, isLoading } = fetchStudies();
+	const { data, isLoading } = fetchStudies('최근 등록순');
 	const studies = data?.studies || ([] as Study[]);
 
 	return (

--- a/src/app/main/mobile/MobileMainPage.tsx
+++ b/src/app/main/mobile/MobileMainPage.tsx
@@ -13,7 +13,7 @@ import './index.scss';
 
 const MobileMainPage = (): JSX.Element => {
 	const history = useHistory();
-	const { data, isLoading } = fetchStudies();
+	const { data, isLoading } = fetchStudies('최근 등록순');
 	const studies = data?.studies || ([] as Study[]);
 
 	const onClick = (category: MainCategoryType) => {

--- a/src/app/modal/StudyFilterModal.tsx
+++ b/src/app/modal/StudyFilterModal.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, memo } from 'react';
 import { Container, Grid } from '@material-ui/core';
 import Modal from '@common/modal/Modal';
 import Chip from '@common/chip/Chip';
@@ -8,15 +8,16 @@ import { ButtonTypeEnum } from '@common/button/types';
 import { IModalContainerCommonProps } from '@common/modal/types';
 import '@common/modal/common.scss';
 import { IconAlignEnum } from '@common/iconButton/types';
-import { IFilterOption } from '@src/app/study/types';
+import { useAtom } from 'jotai';
+import { studyListState } from '@src/state';
 import './studyFilterModal.scss';
 
-const frequencies = ['주 1회', '주 2~4회', '주 5회 이상'];
+const frequencies = ['1회', '주 2-4회', '주 5회 이상'];
 const days = ['월', '화', '수', '목', '금', '토', '일'];
 const places = [
 	'중앙도서관',
-	'학교스터디룸',
-	'일반 카페',
+	'학교 스터디룸',
+	'일반카페',
 	'스터디카페',
 	'서울대입구, 낙성대',
 	'흑석, 상도',
@@ -28,15 +29,16 @@ const places = [
 // 마감항목 표시 버튼 디자인 완료되면 반영 필요
 
 const StudyFilterModal = ({ open, onClose }: IModalContainerCommonProps): JSX.Element => {
-	const [filter, setFilter] = useState({ weekday: [], frequency: [], location: [] } as IFilterOption);
+	const [state, setState] = useAtom(studyListState);
+	const [filter, setFilter] = useState(state?.filterOption);
 
 	const onClickCancel = () => {
 		setFilter({ weekday: [], frequency: [], location: [] });
 	};
 
 	const onClick = () => {
-		// TODO
-		// 필터 적용 API 연동
+		setState({ ...state, filterOption: filter });
+		onClose(false);
 	};
 
 	const onChange = (key: 'frequency' | 'location' | 'weekday', value: string) => {
@@ -110,4 +112,4 @@ const StudyFilterModal = ({ open, onClose }: IModalContainerCommonProps): JSX.El
 	);
 };
 
-export default StudyFilterModal;
+export default memo(StudyFilterModal);

--- a/src/app/modal/StudyFilterModal.tsx
+++ b/src/app/modal/StudyFilterModal.tsx
@@ -31,8 +31,7 @@ const StudyFilterModal = ({ open, onClose }: IModalContainerCommonProps): JSX.El
 	const [filter, setFilter] = useState({ weekday: [], frequency: [], location: [] } as IFilterOption);
 
 	const onClickCancel = () => {
-		// TODO
-		// 필터 clear 로직
+		setFilter({ weekday: [], frequency: [], location: [] });
 	};
 
 	const onClick = () => {

--- a/src/app/modal/StudyFilterModal.tsx
+++ b/src/app/modal/StudyFilterModal.tsx
@@ -8,6 +8,7 @@ import { ButtonTypeEnum } from '@common/button/types';
 import { IModalContainerCommonProps } from '@common/modal/types';
 import '@common/modal/common.scss';
 import { IconAlignEnum } from '@common/iconButton/types';
+import { IFilterOption } from '@src/app/study/types';
 import './studyFilterModal.scss';
 
 const frequencies = ['주 1회', '주 2~4회', '주 5회 이상'];
@@ -27,9 +28,7 @@ const places = [
 // 마감항목 표시 버튼 디자인 완료되면 반영 필요
 
 const StudyFilterModal = ({ open, onClose }: IModalContainerCommonProps): JSX.Element => {
-	const [selectedFrequencies, setSelectedFrequencies] = useState([] as string[]);
-	const [selectedDays, setSelectedDays] = useState([] as string[]);
-	const [selectedPlaces, setSelectedPlaces] = useState([] as string[]);
+	const [filter, setFilter] = useState({ weekday: [], frequency: [], location: [] } as IFilterOption);
 
 	const onClickCancel = () => {
 		// TODO
@@ -41,27 +40,14 @@ const StudyFilterModal = ({ open, onClose }: IModalContainerCommonProps): JSX.El
 		// 필터 적용 API 연동
 	};
 
-	const onChangeFrequencies = (value: string) => {
-		if (selectedFrequencies.includes(value)) {
-			setSelectedFrequencies(selectedFrequencies.filter((item) => item !== value));
+	const onChange = (key: 'frequency' | 'location' | 'weekday', value: string) => {
+		if (filter?.[key]?.includes(value)) {
+			setFilter({ ...filter, [key]: filter?.[key]?.filter((item) => item !== value) });
 		} else {
-			setSelectedFrequencies(selectedFrequencies.concat(value));
-		}
-	};
-
-	const onChangeDays = (value: string) => {
-		if (selectedDays.includes(value)) {
-			setSelectedDays(selectedDays.filter((item) => item !== value));
-		} else {
-			setSelectedDays(selectedDays.concat(value));
-		}
-	};
-
-	const onChangePlaces = (value: string) => {
-		if (selectedPlaces.includes(value)) {
-			setSelectedPlaces(selectedPlaces.filter((item) => item !== value));
-		} else {
-			setSelectedPlaces(selectedPlaces.concat(value).slice(-3));
+			/* eslint no-unused-expressions: ["error", { "allowTernary": true }] */
+			key === 'location'
+				? setFilter({ ...filter, location: filter?.location?.concat(value).slice(-3) })
+				: setFilter({ ...filter, [key]: filter?.[key]?.concat(value) });
 		}
 	};
 
@@ -81,11 +67,11 @@ const StudyFilterModal = ({ open, onClose }: IModalContainerCommonProps): JSX.El
 						<Grid container spacing={1}>
 							{frequencies.map((item) => {
 								const handleClick = () => {
-									onChangeFrequencies(item);
+									onChange('frequency', item);
 								};
 								return (
 									<Grid key={item} item xs={4} className="modal-chip-item">
-										<Chip label={item} selected={selectedFrequencies.includes(item)} onClick={handleClick} />
+										<Chip label={item} selected={filter?.frequency?.includes(item)} onClick={handleClick} />
 									</Grid>
 								);
 							})}
@@ -96,9 +82,11 @@ const StudyFilterModal = ({ open, onClose }: IModalContainerCommonProps): JSX.El
 						<Container className="study-filter-modal-row-flex-container study-filter-modal-row-flex-container-days">
 							{days.map((item) => {
 								const handleClick = () => {
-									onChangeDays(item);
+									onChange('weekday', item);
 								};
-								return <Chip key={item} label={item} selected={selectedDays.includes(item)} onClick={handleClick} />;
+								return (
+									<Chip key={item} label={item} selected={filter?.weekday?.includes(item)} onClick={handleClick} />
+								);
 							})}
 						</Container>
 					</Container>
@@ -108,9 +96,11 @@ const StudyFilterModal = ({ open, onClose }: IModalContainerCommonProps): JSX.El
 						<Container className="study-filter-modal-row-flex-container study-filter-modal-row-flex-container-places">
 							{places.map((item) => {
 								const handleClick = () => {
-									onChangePlaces(item);
+									onChange('location', item);
 								};
-								return <Chip key={item} label={item} selected={selectedPlaces.includes(item)} onClick={handleClick} />;
+								return (
+									<Chip key={item} label={item} selected={filter?.location?.includes(item)} onClick={handleClick} />
+								);
 							})}
 						</Container>
 					</Container>

--- a/src/app/modal/StudySortModal.tsx
+++ b/src/app/modal/StudySortModal.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { memo, useState } from 'react';
 import { Container, Radio, RadioGroup, FormControlLabel } from '@material-ui/core';
 import '@common/modal/common.scss';
 import SimpleModal from '@common/modal/SimpleModal';
@@ -17,7 +17,6 @@ const StudySortModal = ({ open, onClose }: IModalContainerCommonProps): JSX.Elem
 	const onClick = () => {
 		const newOption = sortOptions.find((item) => item.value === selectedOption)!;
 		setState({ ...state, sortOption: newOption });
-		// TODO 정렬 API 연동
 		onClose(false);
 	};
 	const onChange = (evt: React.ChangeEvent<HTMLInputElement>) => {
@@ -46,4 +45,4 @@ const StudySortModal = ({ open, onClose }: IModalContainerCommonProps): JSX.Elem
 	);
 };
 
-export default StudySortModal;
+export default memo(StudySortModal);

--- a/src/app/study/studyList/StudyListContainer.tsx
+++ b/src/app/study/studyList/StudyListContainer.tsx
@@ -7,7 +7,7 @@ import StudyListPresenter from './StudyListPresenter';
 
 const StudyListContainter = (): JSX.Element => {
 	const [state] = useAtom(studyListState);
-	const { data, isLoading } = fetchStudies(state?.sortOption?.value);
+	const { data, isLoading } = fetchStudies(state?.sortOption?.value, state?.filterOption);
 	return isLoading ? <Loader /> : <StudyListPresenter data={data?.studies} />;
 };
 

--- a/src/app/study/studyList/StudyListContainer.tsx
+++ b/src/app/study/studyList/StudyListContainer.tsx
@@ -1,11 +1,14 @@
-import React from 'react';
+import React, { memo } from 'react';
 import fetchStudies from '@src/hooks/remotes/study/useFetchStudies';
 import Loader from '@common/loader/Loader';
+import { useAtom } from 'jotai';
+import { studyListState } from '@src/state';
 import StudyListPresenter from './StudyListPresenter';
 
 const StudyListContainter = (): JSX.Element => {
-	const { data, isLoading } = fetchStudies();
+	const [state] = useAtom(studyListState);
+	const { data, isLoading } = fetchStudies(state?.sortOption?.value);
 	return isLoading ? <Loader /> : <StudyListPresenter data={data?.studies} />;
 };
 
-export default StudyListContainter;
+export default memo(StudyListContainter);

--- a/src/app/study/studySortFilter/StudySortFilterContainer.tsx
+++ b/src/app/study/studySortFilter/StudySortFilterContainer.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { memo } from 'react';
 import useModal from '@src/hooks/modal/useModal';
 import ModalKeyEnum from '@common/modal/enum';
 import { useAtom } from 'jotai';
@@ -19,7 +19,7 @@ const StudySortFilterContainter = (): JSX.Element => {
 
 	const { sortOption } = state;
 
-	return <StudySortFilterPresenter onClickFilter={onClickFilter} onClickSort={onClickSort} sort={sortOption.label} />;
+	return <StudySortFilterPresenter onClickFilter={onClickFilter} onClickSort={onClickSort} sort={sortOption?.label} />;
 };
 
-export default StudySortFilterContainter;
+export default memo(StudySortFilterContainter);

--- a/src/app/study/types.ts
+++ b/src/app/study/types.ts
@@ -5,7 +5,14 @@ export interface ISortOption {
 	label: string;
 }
 
+export interface IFilterOption {
+	frequency: string[];
+	weekday: string[];
+	location: string[];
+}
+
 export interface IStudyListState {
 	sortOption: ISortOption;
+	filterOption: IFilterOption;
 	selectedSubCategories: CategoryType[];
 }

--- a/src/const.ts
+++ b/src/const.ts
@@ -169,10 +169,10 @@ export const categories: MainCategoryType[] = [
 ];
 
 export const sortOptions = [
-	{ value: 'created_at:desc', label: '최신순' },
-	{ value: 'created_at:asc', label: '오래된 순' },
-	{ value: 'vacancies:desc', label: '남은 인원: 많은 순' },
-	{ value: 'vacancies:asc', label: '남은 인원: 적은 순' },
+	{ value: '최근 등록순', label: '최신순' },
+	{ value: '오래된 순', label: '오래된 순' },
+	{ value: '남은 모집인원: 많은 순', label: '남은 인원: 많은 순' },
+	{ value: '남은 모집인원: 적은 순', label: '남은 인원: 적은 순' },
 ];
 
 // FIXME 수정

--- a/src/hooks/remotes/study/useFetchStudies.ts
+++ b/src/hooks/remotes/study/useFetchStudies.ts
@@ -2,15 +2,32 @@ import { useQuery } from 'react-query';
 import API from '@src/api';
 import { IResponseGetStudies } from '@api/response/study';
 import QUERY_KEY from '@src/hooks/remotes';
-// TODO
-// parameter
-export default (orderBy?: string) => {
+import { IFilterOption } from '@src/app/study/types';
+
+export default (orderBy: string, filter?: IFilterOption) => {
 	const fetcher = async (): Promise<IResponseGetStudies> => {
-		const res = await API.getStudies(orderBy);
+		const res = await API.getStudies(orderBy, filter);
 		return res.data;
 	};
 
-	return useQuery(`${QUERY_KEY.FETCH_STUDIES}/${orderBy}`, fetcher, {
+	let queryKey = `${QUERY_KEY.FETCH_STUDIES}/${orderBy}`;
+	if (filter?.frequency?.length) {
+		queryKey += filter?.frequency?.reduce((acc, cur) => {
+			return acc + cur;
+		}, '');
+	}
+	if (filter?.location?.length) {
+		queryKey += filter?.location?.reduce((acc, cur) => {
+			return acc + cur;
+		}, '');
+	}
+	if (filter?.weekday?.length) {
+		queryKey += filter?.weekday?.reduce((acc, cur) => {
+			return acc + cur;
+		}, '');
+	}
+
+	return useQuery(queryKey, fetcher, {
 		onError: (e) => {
 			console.log(e);
 		},

--- a/src/hooks/remotes/study/useFetchStudies.ts
+++ b/src/hooks/remotes/study/useFetchStudies.ts
@@ -2,16 +2,15 @@ import { useQuery } from 'react-query';
 import API from '@src/api';
 import { IResponseGetStudies } from '@api/response/study';
 import QUERY_KEY from '@src/hooks/remotes';
-
 // TODO
 // parameter
-export default () => {
+export default (orderBy?: string) => {
 	const fetcher = async (): Promise<IResponseGetStudies> => {
-		const res = await API.getStudies();
+		const res = await API.getStudies(orderBy);
 		return res.data;
 	};
 
-	return useQuery(QUERY_KEY.FETCH_STUDIES, fetcher, {
+	return useQuery(`${QUERY_KEY.FETCH_STUDIES}/${orderBy}`, fetcher, {
 		onError: (e) => {
 			console.log(e);
 		},

--- a/src/hooks/remotes/study/useFetchStudies.ts
+++ b/src/hooks/remotes/study/useFetchStudies.ts
@@ -12,19 +12,13 @@ export default (orderBy: string, filter?: IFilterOption) => {
 
 	let queryKey = `${QUERY_KEY.FETCH_STUDIES}/${orderBy}`;
 	if (filter?.frequency?.length) {
-		queryKey += filter?.frequency?.reduce((acc, cur) => {
-			return acc + cur;
-		}, '');
+		queryKey += filter?.frequency?.join(',');
 	}
 	if (filter?.location?.length) {
-		queryKey += filter?.location?.reduce((acc, cur) => {
-			return acc + cur;
-		}, '');
+		queryKey += filter?.location?.join(',');
 	}
 	if (filter?.weekday?.length) {
-		queryKey += filter?.weekday?.reduce((acc, cur) => {
-			return acc + cur;
-		}, '');
+		queryKey += filter?.weekday?.join(',');
 	}
 
 	return useQuery(queryKey, fetcher, {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -5,7 +5,13 @@ import { QueryClient, QueryClientProvider } from 'react-query';
 import reportWebVitals from './reportWebVitals';
 import './index.scss';
 
-const queryClient = new QueryClient();
+const queryClient = new QueryClient({
+	defaultOptions: {
+		queries: {
+			refetchOnWindowFocus: false,
+		},
+	},
+});
 ReactDOM.render(
 	<QueryClientProvider client={queryClient}>
 		<App />

--- a/src/state.ts
+++ b/src/state.ts
@@ -32,6 +32,11 @@ const globalState = atom({
 
 export const studyListState = atom({
 	sortOption: sortOptions[0],
+	filterOption: {
+		weekday: [],
+		frequency: [],
+		location: [],
+	},
 	selectedSubCategories: [] as CategoryType[],
 } as IStudyListState);
 


### PR DESCRIPTION
스터디 목록 페이지에 정렬 및 필터 기능을 추가했습니다. 

**참고**
필터링의 경우 멀티 필터링 (e.g. weekday=월, 목 등) 호출 방식을 백엔드에 문의드린 상태이고, 답변을 받으면 별도 PR 하겠습니다. 
현재는 항목별 단일 필터링 (e.g. weekday=월&location=일반카페&frequency=1회 형태) 만 동작하도록 구현되어 있습니다! 