### PR TITLE
feat: 스터디 리스트 > 필터 활성화 상태 구현

### DIFF
--- a/src/app/study/studySortFilter/StudySortFilterContainer.tsx
+++ b/src/app/study/studySortFilter/StudySortFilterContainer.tsx
@@ -1,4 +1,4 @@
-import React, { memo } from 'react';
+import React, { memo, useMemo } from 'react';
 import useModal from '@src/hooks/modal/useModal';
 import ModalKeyEnum from '@common/modal/enum';
 import { useAtom } from 'jotai';
@@ -17,9 +17,21 @@ const StudySortFilterContainter = (): JSX.Element => {
 		openModal(ModalKeyEnum.StudySortModal);
 	};
 
-	const { sortOption } = state;
+	const { sortOption, filterOption } = state;
 
-	return <StudySortFilterPresenter onClickFilter={onClickFilter} onClickSort={onClickSort} sort={sortOption?.label} />;
+	const filterNum = useMemo(() => {
+		const { frequency, weekday, location } = filterOption;
+		return Number(!!frequency?.length) + Number(!!weekday?.length) + Number(!!location?.length);
+	}, [filterOption]);
+
+	return (
+		<StudySortFilterPresenter
+			onClickFilter={onClickFilter}
+			onClickSort={onClickSort}
+			sort={sortOption?.label}
+			filterNum={filterNum}
+		/>
+	);
 };
 
 export default memo(StudySortFilterContainter);

--- a/src/app/study/studySortFilter/StudySortFilterPresenter.tsx
+++ b/src/app/study/studySortFilter/StudySortFilterPresenter.tsx
@@ -1,18 +1,21 @@
 import React from 'react';
 import { Container } from '@material-ui/core';
 import { IoOptions, IoChevronDown } from 'react-icons/io5';
+import classNames from 'classnames';
 import './index.scss';
 
 interface IStudySortFilterPresenterProps {
 	onClickFilter: () => void;
 	onClickSort: () => void;
 	sort: string;
+	filterNum: number;
 }
 
 const StudySortFilterPresenter = ({
 	onClickFilter,
 	sort,
 	onClickSort,
+	filterNum,
 }: IStudySortFilterPresenterProps): JSX.Element => {
 	return (
 		<Container className="study-sort-filter-presenter-container">
@@ -20,8 +23,12 @@ const StudySortFilterPresenter = ({
 				<span>{sort}</span>
 				<IoChevronDown size={16} />
 			</Container>
-			<Container className="study-sort-filter-presenter-container-filter" onClick={onClickFilter}>
+			<Container
+				className={classNames('study-sort-filter-presenter-container-filter', { enabled: !!filterNum })}
+				onClick={onClickFilter}
+			>
 				<IoOptions size={16} />
+				{!!filterNum && <span className="study-sort-filter-presenter-filter-chip">{filterNum}</span>}
 				<span>필터</span>
 			</Container>
 		</Container>

--- a/src/app/study/studySortFilter/index.scss
+++ b/src/app/study/studySortFilter/index.scss
@@ -36,7 +36,29 @@
     display: flex !important;
     justify-content: center;
     align-items: center;
+    position: relative;
     svg {
         margin-right: .5rem;
     }
+    &.enabled {
+        color: #fff;
+        background-color: $primaryColor;
+    }
+}
+
+.study-sort-filter-presenter-filter-chip {
+    width: 1.5rem !important;
+    height: 1.5rem;
+    border: 1px solid $primaryColor;
+    border-radius: 20px;
+    color: $primaryColor;
+    font-weight: bold !important;
+    font-size: .8rem;
+    position: absolute;
+    background: #fff;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    top: -1rem;
+    right: -0.5rem;
 }


### PR DESCRIPTION
스터디 리스트 페이지에서 필터가 활성화된 상태 (bg 컬러, font 컬러 변경 및 우측 상단 칩) 마크업을 추가했습니다. 
<img width="389" alt="스크린샷 2022-03-27 오후 9 15 50" src="https://user-images.githubusercontent.com/56914200/160280989-4a0cf3c8-275f-47de-9fc8-85620fabb0c3.png">

**참고**
모바일 디자인은 아직 확정되지 않아서, 확정된 이후 수정할 예정입니다! 