### PR TITLE
Feat/fix login logout snackbar

### DIFF
--- a/src/app/main/button/MainButton.tsx
+++ b/src/app/main/button/MainButton.tsx
@@ -6,6 +6,8 @@ import useModal from '@src/hooks/modal/useModal';
 import ModalKeyEnum from '@src/components/common/modal/enum';
 import { useAtom } from 'jotai';
 import globalState from '@src/state';
+import { useHistory } from 'react-router-dom';
+import useSnackbar from '@src/hooks/snackbar/useSnackbar';
 
 interface IMainButtonProps {
 	isDesktop?: boolean;
@@ -13,10 +15,12 @@ interface IMainButtonProps {
 
 const MainButton = ({ isDesktop = false }: IMainButtonProps) => {
 	const { openModal } = useModal();
+	const history = useHistory();
+	const { openSnackbar } = useSnackbar();
 	const [state] = useAtom(globalState);
 	const onClick = () => {
 		if (!state.login) {
-			openModal(ModalKeyEnum.LoginModal);
+			openModal(ModalKeyEnum.LoginModal, { history, openSnackbar });
 			return;
 		}
 		openModal(ModalKeyEnum.StudyPostModal);

--- a/src/app/modal/LoginModal.tsx
+++ b/src/app/modal/LoginModal.tsx
@@ -5,7 +5,6 @@ import Modal from '@src/components/common/modal/Modal';
 import { IModalContainerCommonProps } from '@src/components/common/modal/types';
 import CommonTextField from '@src/components/common/textfield/CommonTextField';
 import usePostLogin from '@src/hooks/remotes/user/usePostLogin';
-import useSnackbar from '@src/hooks/snackbar/useSnackbar';
 import globalState from '@src/state';
 import logoDefaultBlue from '@src/assets/img/logo/logoDefaultBlue.svg';
 import { useAtom } from 'jotai';
@@ -22,9 +21,9 @@ const LoginModal = ({ open, onClose }: IModalContainerCommonProps): JSX.Element 
 	const [passwordHelperText, setPasswordHelperText] = useState<string>('');
 
 	const postLogin = usePostLogin(setLoginSuccess);
-	const { openSnackbar } = useSnackbar();
 	const [state, setState] = useAtom(globalState);
 	const history = state.modal.params?.history;
+	const openSnackbar = state.modal.params?.openSnackbar;
 
 	const resetPw = () => {
 		onClose(false);
@@ -68,6 +67,7 @@ const LoginModal = ({ open, onClose }: IModalContainerCommonProps): JSX.Element 
 				...state,
 			});
 			onClose(false);
+			openSnackbar('로그인에 성공하였습니다.');
 		} else {
 			setEmailHelperText('가입하지 않은 아이디거나, 잘못된 비밀번호입니다.');
 			setPasswordHelperText('가입하지 않은 아이디거나, 잘못된 비밀번호입니다.');

--- a/src/app/shared/components/header/index.tsx
+++ b/src/app/shared/components/header/index.tsx
@@ -8,6 +8,8 @@ import LogoFullWidth from '@src/assets/img/logo/logoFullWidth.svg';
 import logoDefaultWhite from '@src/assets/img/logo/logoDefaultWhite.svg';
 import logoDefaultBlue from '@src/assets/img/logo/logoDefaultBlue.svg';
 import LogoDefaultVertical from '@src/assets/img/logo/logoDefaultVertical.svg';
+import useSnackbar from '@src/hooks/snackbar/useSnackbar';
+
 import classNames from 'classnames';
 import { useAtom } from 'jotai';
 import React, { useCallback, useMemo, useState } from 'react';
@@ -20,6 +22,7 @@ const Header: React.FC = () => {
 	const history = useHistory();
 	const locationPathName = useLocation().pathname;
 	const { openModal } = useModal();
+	const { openSnackbar } = useSnackbar();
 	const [state] = useAtom(globalState);
 
 	const [isDrawerOpen, setIsDrawerOpen] = useState(false);
@@ -83,7 +86,7 @@ const Header: React.FC = () => {
 		return (
 			<div className="header-icons-con">
 				<IoSearch onClick={clickSearchIcon} className="header-icon desktop-visible" color={iconColor} />
-				<Button onClick={() => openModal(ModalKeyEnum.LoginModal, { history })}>
+				<Button onClick={() => openModal(ModalKeyEnum.LoginModal, { history, openSnackbar })}>
 					<Typography className="header-login">로그인</Typography>
 				</Button>
 			</div>
@@ -104,7 +107,7 @@ const Header: React.FC = () => {
 					onClick={() => {
 						if (drawerItem?.isLogin) {
 							setIsDrawerOpen(false);
-							openModal(ModalKeyEnum.LoginModal, { history });
+							openModal(ModalKeyEnum.LoginModal, { history, openSnackbar });
 						}
 					}}
 					divider={drawerItemIdx === drawerItemLength - 1 && drawerSubListIdx !== drawerSubListLength - 1}

--- a/src/app/study/mobile/MobileStudyPage.tsx
+++ b/src/app/study/mobile/MobileStudyPage.tsx
@@ -12,18 +12,22 @@ import { Container } from '@material-ui/core';
 import './index.scss';
 import useModal from '@src/hooks/modal/useModal';
 import ModalKeyEnum from '@src/components/common/modal/enum';
+import { useHistory } from 'react-router-dom';
+import useSnackbar from '@src/hooks/snackbar/useSnackbar';
 
 const MobileStudyPage = (): JSX.Element => {
 	const [mainCategory, setMainCategory] = useState<MainCategoryType>();
 	const [state, setState] = useAtom(studyListState);
 	const [gState] = useAtom(globalState);
 	const { openModal } = useModal();
+	const history = useHistory();
+	const { openSnackbar } = useSnackbar();
 
 	const { filterOption } = state;
 
 	const onClickCreate = () => {
 		if (!gState.login) {
-			openModal(ModalKeyEnum.LoginModal);
+			openModal(ModalKeyEnum.LoginModal, { history, openSnackbar });
 			return;
 		}
 		openModal(ModalKeyEnum.StudyPostModal);

--- a/src/app/studyDetail/studyContent/ask/comments/CommentItem.tsx
+++ b/src/app/studyDetail/studyContent/ask/comments/CommentItem.tsx
@@ -7,6 +7,8 @@ import { Comment } from '@src/api/types';
 import { useAtom } from 'jotai';
 import globalState from '@src/state';
 import useDeleteStudyComment from '@src/hooks/remotes/comment/useDeleteStudyComment';
+import { useHistory } from 'react-router-dom';
+import useSnackbar from '@src/hooks/snackbar/useSnackbar';
 
 interface CommentItemProps {
 	comment: Comment;
@@ -19,6 +21,8 @@ const CommentItem = ({ comment, hostId, setShowCommentInput, studyId }: CommentI
 	const [state] = useAtom(globalState);
 	const myId = state.userId;
 	const { openModal } = useModal();
+	const history = useHistory();
+	const { openSnackbar } = useSnackbar();
 	const deleteComment = useDeleteStudyComment(studyId, comment.id);
 
 	const onClickReport = () => {
@@ -53,7 +57,7 @@ const CommentItem = ({ comment, hostId, setShowCommentInput, studyId }: CommentI
 								type="button"
 								onClick={() => {
 									if (!state.login) {
-										openModal(ModalKeyEnum.LoginModal);
+										openModal(ModalKeyEnum.LoginModal, { history, openSnackbar });
 										return;
 									}
 									if (setShowCommentInput) setShowCommentInput(true);

--- a/src/hooks/remotes/user/usePatchLogout.ts
+++ b/src/hooks/remotes/user/usePatchLogout.ts
@@ -1,9 +1,11 @@
 import API from '@src/api';
+import useSnackbar from '@src/hooks/snackbar/useSnackbar';
 import { useMutation, useQuery } from 'react-query';
 import { useHistory } from 'react-router-dom';
 
 export default () => {
 	const history = useHistory();
+	const { openSnackbar } = useSnackbar();
 
 	const mutation = async (): Promise<any> => {
 		const res = await API.logout();
@@ -12,7 +14,7 @@ export default () => {
 	return useMutation(mutation, {
 		onSuccess: (response: any) => {
 			console.log(response);
-			history.push('/');
+			openSnackbar('로그아웃되었습니다.');
 		},
 		onError: (e: Error) => {
 			console.error(e.message);

--- a/src/pages/studyDetail/index.tsx
+++ b/src/pages/studyDetail/index.tsx
@@ -2,7 +2,7 @@ import StudyContentContainer from '@src/app/studyDetail/studyContent/StudyConten
 import StudyInfoContainer from '@src/app/studyDetail/studyInfo/StudyInfoContainer';
 import React, { useCallback, useMemo } from 'react';
 import { IoBookmarkOutline, IoEllipsisVertical, IoPencil, IoShareSocialOutline } from 'react-icons/io5';
-import { useParams, useLocation } from 'react-router-dom';
+import { useParams, useLocation, useHistory } from 'react-router-dom';
 import { CopyToClipboard } from 'react-copy-to-clipboard';
 import useModal from '@src/hooks/modal/useModal';
 import './styles.scss';
@@ -32,6 +32,7 @@ const StudyDetailPage = (): JSX.Element => {
 
 	const { openModal } = useModal();
 	const { openSnackbar } = useSnackbar();
+	const history = useHistory();
 	const [state] = useAtom(globalState);
 
 	const isHost = useMemo(() => {
@@ -40,7 +41,7 @@ const StudyDetailPage = (): JSX.Element => {
 
 	const onClick = () => {
 		if (!state.login) {
-			openModal(ModalKeyEnum.LoginModal);
+			openModal(ModalKeyEnum.LoginModal, { history, openSnackbar });
 			return;
 		}
 		if (isHost) {
@@ -69,7 +70,7 @@ const StudyDetailPage = (): JSX.Element => {
 
 	const onClickPostBookmark = () => {
 		if (!state.login) {
-			openModal(ModalKeyEnum.LoginModal);
+			openModal(ModalKeyEnum.LoginModal, { history, openSnackbar });
 			return;
 		}
 		postBookmark.mutate();


### PR DESCRIPTION
- login, logout 성공 시 snackbar가 호출되도록 추가하였습니다.
- 로그인 모달을 호출할 떄 history와 openSnackbar를 파라미터로 넘겨주는데 참고해주시면 감사드리겠습니다! @taechonkim 
- 로그인 모달 함수 내에서 useHistory와 useSnackbar를 선언해서 사용하면 잘 작동이 안 되어서 외부에서 선언해서 파라미터로 넘기는데 이 부분 개선할 수 있으면 알려주시면 감사드리겠습니다 🙇 
```javascript
const history = useHistory();
const { openSnackbar } = useSnackbar();

openModal(ModalKeyEnum.LoginModal, { history, openSnackbar });
```


