### PR TITLE
Feat/fix user id state after login

### DIFF
--- a/src/app/modal/LoginModal.tsx
+++ b/src/app/modal/LoginModal.tsx
@@ -5,7 +5,7 @@ import Modal from '@src/components/common/modal/Modal';
 import { IModalContainerCommonProps } from '@src/components/common/modal/types';
 import CommonTextField from '@src/components/common/textfield/CommonTextField';
 import usePostLogin from '@src/hooks/remotes/user/usePostLogin';
-import globalState from '@src/state';
+import globalState, { userState as globalUserState } from '@src/state';
 import logoDefaultBlue from '@src/assets/img/logo/logoDefaultBlue.svg';
 import { useAtom } from 'jotai';
 import React, { KeyboardEvent, useCallback, useEffect, useState } from 'react';
@@ -21,6 +21,7 @@ const LoginModal = ({ open, onClose }: IModalContainerCommonProps): JSX.Element 
 
 	const postLogin = usePostLogin();
 	const [state, setState] = useAtom(globalState);
+	const [userState, setUserState] = useAtom(globalUserState);
 	const history = state.modal.params?.history;
 	const openSnackbar = state.modal.params?.openSnackbar;
 
@@ -58,7 +59,7 @@ const LoginModal = ({ open, onClose }: IModalContainerCommonProps): JSX.Element 
 
 	useEffect(() => {
 		if (postLogin.isSuccess && postLogin.data) {
-			setState({ ...state, userId: postLogin.data.userId });
+			setUserState({ ...userState, userId: postLogin.data.userId });
 			openSnackbar('로그인에 성공하였습니다.');
 		} else if (postLogin.isError) {
 			setEmailHelperText('가입하지 않은 아이디거나, 잘못된 비밀번호입니다.');

--- a/src/app/modal/LoginModal.tsx
+++ b/src/app/modal/LoginModal.tsx
@@ -14,13 +14,12 @@ import { validateEmail } from '../shared/utils/validation';
 import './loginModal.scss';
 
 const LoginModal = ({ open, onClose }: IModalContainerCommonProps): JSX.Element => {
-	const [loginSuccess, setLoginSuccess] = useState<boolean | undefined>();
 	const [email, setEmail] = useState<string>('');
 	const [password, setPassword] = useState<string>('');
 	const [emailHelperText, setEmailHelperText] = useState<string>('');
 	const [passwordHelperText, setPasswordHelperText] = useState<string>('');
 
-	const postLogin = usePostLogin(setLoginSuccess);
+	const postLogin = usePostLogin();
 	const [state, setState] = useAtom(globalState);
 	const history = state.modal.params?.history;
 	const openSnackbar = state.modal.params?.openSnackbar;
@@ -58,22 +57,14 @@ const LoginModal = ({ open, onClose }: IModalContainerCommonProps): JSX.Element 
 	}, [email, password]);
 
 	useEffect(() => {
-		if (loginSuccess === undefined) {
-			return;
-		}
-
-		if (loginSuccess) {
-			setState({
-				...state,
-			});
-			onClose(false);
+		if (postLogin.isSuccess && postLogin.data) {
+			setState({ ...state, userId: postLogin.data.userId });
 			openSnackbar('로그인에 성공하였습니다.');
-		} else {
+		} else if (postLogin.isError) {
 			setEmailHelperText('가입하지 않은 아이디거나, 잘못된 비밀번호입니다.');
 			setPasswordHelperText('가입하지 않은 아이디거나, 잘못된 비밀번호입니다.');
-			setLoginSuccess(undefined);
 		}
-	}, [loginSuccess]);
+	}, [postLogin.isSuccess, postLogin.isError, postLogin.data]);
 
 	return (
 		<Modal open={open} onClose={onClose} isFullHeight>

--- a/src/app/profile/my/header/MyHeaderContainer.tsx
+++ b/src/app/profile/my/header/MyHeaderContainer.tsx
@@ -1,14 +1,14 @@
 import useFetchUser from '@src/hooks/remotes/user/useFetchUser';
 import useFetchUserProfile from '@src/hooks/remotes/user/useFetchUserProfile';
-import globalState from '@src/state';
+import { userState as globalUserState } from '@src/state';
 import { useAtom } from 'jotai';
 import React from 'react';
 import MyHeaderPresenter from './MyHeaderPresenter';
 
 const MyHeaderContainer = (): JSX.Element => {
-	const [state, setState] = useAtom(globalState);
+	const [userState] = useAtom(globalUserState);
 
-	const userProfile = useFetchUserProfile(state.userId).data?.userProfile;
+	const userProfile = useFetchUserProfile(userState.userId).data?.userProfile;
 	const userEmail = useFetchUser().data?.data.email;
 
 	return <div>{userProfile && userEmail && <MyHeaderPresenter userProfile={userProfile} userEmail={userEmail} />}</div>;

--- a/src/app/profile/my/header/MyHeaderPresenter.tsx
+++ b/src/app/profile/my/header/MyHeaderPresenter.tsx
@@ -11,7 +11,7 @@ import useModal from '@src/hooks/modal/useModal';
 import ModalKeyEnum from '@src/components/common/modal/enum';
 import { Box, ButtonBase } from '@material-ui/core';
 import { useAtom } from 'jotai';
-import globalState from '@src/state';
+import { userState as globalUserState } from '@src/state';
 
 interface MyHeaderPresenterProps {
 	userProfile: UserProfile;
@@ -20,11 +20,11 @@ interface MyHeaderPresenterProps {
 
 const MyHeaderPresenter = ({ userProfile, userEmail }: MyHeaderPresenterProps): JSX.Element => {
 	const history = useHistory();
-	const [state, setState] = useAtom(globalState);
+	const [userState] = useAtom(globalUserState);
 	const { openModal } = useModal();
 
 	const showProfileSheet = () => {
-		openModal(ModalKeyEnum.UserProfileModal, { userId: state.userId });
+		openModal(ModalKeyEnum.UserProfileModal, { userId: userState.userId });
 	};
 
 	return (

--- a/src/app/profile/myProfileEdit/MyProfileEditContainer.tsx
+++ b/src/app/profile/myProfileEdit/MyProfileEditContainer.tsx
@@ -1,14 +1,14 @@
 import { Container } from '@material-ui/core';
 import Loader from '@src/components/common/loader/Loader';
 import useFetchUserProfile from '@src/hooks/remotes/user/useFetchUserProfile';
-import globalState from '@src/state';
+import { userState as globalUserState } from '@src/state';
 import { useAtom } from 'jotai';
 import React from 'react';
 import MyProfileEditPresenter, { UrlInterface } from './MyProfileEditPresenter';
 
 const MyProfileEditContainer = (): JSX.Element => {
-	const [state, setState] = useAtom(globalState);
-	const { data, isLoading } = useFetchUserProfile(state.userId);
+	const [userState] = useAtom(globalUserState);
+	const { data, isLoading } = useFetchUserProfile(userState.userId);
 	const userProfile = data?.userProfile;
 
 	const urlInitialValue: Array<UrlInterface> = [];

--- a/src/app/profile/myProfileEdit/MyProfileEditPresenter.tsx
+++ b/src/app/profile/myProfileEdit/MyProfileEditPresenter.tsx
@@ -14,7 +14,7 @@ import usePatchUserProfile from '@src/hooks/remotes/user/usePatchUserProfile';
 import classNames from 'classnames';
 import CommonTextField from '@src/components/common/textfield/CommonTextField';
 import { useAtom } from 'jotai';
-import globalState from '@src/state';
+import { userState as globalUserState } from '@src/state';
 
 export interface UrlInterface {
 	urlId: number;
@@ -45,7 +45,7 @@ const MyProfileEditPresenter = ({
 	longIntro,
 }: MyProfileEditPresenterProps): JSX.Element => {
 	const updateProfile = usePatchUserProfile();
-	const [state, setState] = useAtom(globalState);
+	const [userState] = useAtom(globalUserState);
 
 	const [accUrlId, setAccUrlId] = useState<number>(urls.length);
 	const [currentNickname, setCurrentNickname] = useState<string>(nickname);
@@ -65,7 +65,7 @@ const MyProfileEditPresenter = ({
 		});
 
 		updateProfile.mutate({
-			userId: state.userId,
+			userId: userState.userId,
 			userName: currentNickname,
 			dept: currentMajor,
 			grade: String(currentGrade),

--- a/src/app/studyDetail/studyContent/ask/comments/CommentItem.tsx
+++ b/src/app/studyDetail/studyContent/ask/comments/CommentItem.tsx
@@ -5,7 +5,7 @@ import ModalKeyEnum from '@common/modal/enum';
 import format from 'date-fns/format';
 import { Comment } from '@src/api/types';
 import { useAtom } from 'jotai';
-import globalState from '@src/state';
+import globalState, { userState as globalUserState } from '@src/state';
 import useDeleteStudyComment from '@src/hooks/remotes/comment/useDeleteStudyComment';
 import { useHistory } from 'react-router-dom';
 import useSnackbar from '@src/hooks/snackbar/useSnackbar';
@@ -19,7 +19,8 @@ interface CommentItemProps {
 
 const CommentItem = ({ comment, hostId, setShowCommentInput, studyId }: CommentItemProps): JSX.Element => {
 	const [state] = useAtom(globalState);
-	const myId = state.userId;
+	const [userState] = useAtom(globalUserState);
+	const myId = userState.userId;
 	const { openModal } = useModal();
 	const history = useHistory();
 	const { openSnackbar } = useSnackbar();

--- a/src/hooks/remotes/user/usePatchLogout.ts
+++ b/src/hooks/remotes/user/usePatchLogout.ts
@@ -1,11 +1,14 @@
 import API from '@src/api';
 import useSnackbar from '@src/hooks/snackbar/useSnackbar';
+import { useAtom } from 'jotai';
 import { useMutation, useQuery } from 'react-query';
 import { useHistory } from 'react-router-dom';
+import { userState as globalUserState } from '@src/state';
 
 export default () => {
 	const history = useHistory();
 	const { openSnackbar } = useSnackbar();
+	const [userState, setUserState] = useAtom(globalUserState);
 
 	const mutation = async (): Promise<any> => {
 		const res = await API.logout();
@@ -15,6 +18,7 @@ export default () => {
 		onSuccess: (response: any) => {
 			console.log(response);
 			openSnackbar('로그아웃되었습니다.');
+			setUserState({ ...userState, userId: '' });
 		},
 		onError: (e: Error) => {
 			console.error(e.message);

--- a/src/hooks/remotes/user/usePostLogin.ts
+++ b/src/hooks/remotes/user/usePostLogin.ts
@@ -1,13 +1,9 @@
 import { useMutation } from 'react-query';
 import { IRequestLogin } from '@api/request/user';
 import API from '@src/api';
-import { useAtom } from 'jotai';
-import globalState from '@src/state';
 import { IPostLogin } from '@src/api/response/login';
 
-export default (setSuccess: React.Dispatch<React.SetStateAction<boolean | undefined>>) => {
-	const [state, setState] = useAtom(globalState);
-
+export default () => {
 	const mutation = async (request: IRequestLogin) => {
 		const res = await API.login(request);
 		return res.data;
@@ -16,12 +12,9 @@ export default (setSuccess: React.Dispatch<React.SetStateAction<boolean | undefi
 	return useMutation(mutation, {
 		onSuccess: (response: IPostLogin) => {
 			console.log(response);
-			setSuccess(true);
-			setState({ ...state, userId: response?.userId });
 		},
 		onError: (e: Error) => {
 			console.error(e.message);
-			setSuccess(false);
 		},
 	});
 };

--- a/src/pages/studyDetail/index.tsx
+++ b/src/pages/studyDetail/index.tsx
@@ -14,7 +14,7 @@ import { Button, ButtonGroup, IconButton } from '@material-ui/core';
 import CommonButton from '@src/components/common/button/CommonButton';
 import usePostBookmark from '@src/hooks/remotes/bookmark/usePostBookmark';
 import { useAtom } from 'jotai';
-import globalState from '@src/state';
+import globalState, { userState as globalUserState } from '@src/state';
 import { getMainCategoryCode } from '@src/app/shared/utils/category';
 import useWindowDimensions from '@src/hooks/useWindowDimensions';
 
@@ -92,6 +92,7 @@ const StudyDetailPage = (): JSX.Element => {
 	const { openSnackbar } = useSnackbar();
 	const history = useHistory();
 	const [state] = useAtom(globalState);
+	const [userState] = useAtom(globalUserState);
 	const { width } = useWindowDimensions();
 
 	const isDesktop = useMemo(() => {
@@ -99,7 +100,7 @@ const StudyDetailPage = (): JSX.Element => {
 	}, [width]);
 
 	const isHost = useMemo(() => {
-		return state.userId === studyData?.HOST_ID;
+		return userState.userId === studyData?.HOST_ID;
 	}, [studyData]);
 
 	const onClick = () => {

--- a/src/state.ts
+++ b/src/state.ts
@@ -5,6 +5,7 @@ import { IGlobalModalProps } from '@common/modal/types';
 import { IStudyListState } from '@src/app/study/types';
 import { sortOptions } from '@src/const';
 import { CategoryType } from '@src/types';
+import { atomWithStorage } from 'jotai/utils';
 
 interface IGlobalStateProps {
 	login: boolean;
@@ -40,5 +41,9 @@ export const studyListState = atom({
 		pageNo: 1,
 	},
 } as IStudyListState);
+
+export const userState = atomWithStorage('userState', {
+	userId: '',
+});
 
 export default globalState;

--- a/src/state.ts
+++ b/src/state.ts
@@ -15,9 +15,6 @@ interface IGlobalStateProps {
 
 const globalState = atom({
 	login: !!getCookie('accessToken'),
-	// FIXME
-	// 로그인 기능 구현 이후 수정 필요
-	userId: '28464dc7-7537-4b91-9d52-764b6de32122',
 	snackbar: {
 		open: false,
 		message: '',


### PR DESCRIPTION
- 로그인 성공 시 userid를 전역적인 값으로 localStorage에 저장하도록 구현했습니다.
- localStorage에 저장하지 않을 시 다른 페이지로 이동하게 되면 저장된 상태가 초기 상태 값으로 바뀌던데 jotai에서는 원래 이렇게 작동하는 건가요..? (이러한 이슈 떄문에 localStorage에 저장을 해주는 atomWithStorage를 사용하였습니다!) 
- #336 