### PR TITLE
fix: 스터디 신청 모달 버그 수정

### DIFF
--- a/src/app/modal/ApplyModal.tsx
+++ b/src/app/modal/ApplyModal.tsx
@@ -1,4 +1,4 @@
-import React, { ChangeEvent, useCallback, useState, useMemo } from 'react';
+import React, { ChangeEvent, useCallback, useEffect, useState, useMemo } from 'react';
 import './applyModal.scss';
 import { Container } from '@material-ui/core';
 import Modal from '@common/modal/Modal';
@@ -9,13 +9,15 @@ import { IModalContainerCommonProps } from '@common/modal/types';
 import '@common/modal/common.scss';
 import usePostStudyUser from '@src/hooks/remotes/studyUser/usePostStudyUser';
 import { useAtom } from 'jotai';
-import globalState from '@src/state';
+import globalState, { userState as globalUserState } from '@src/state';
 import useFetchUserProfile from '@src/hooks/remotes/user/useFetchUserProfile';
 
 const ApplyModal = ({ open, onClose }: IModalContainerCommonProps): JSX.Element => {
 	const postStudyUser = usePostStudyUser();
 	const [state] = useAtom(globalState);
-	const { modal, userId } = state;
+	const [userState] = useAtom(globalUserState);
+	const { modal } = state;
+	const { userId } = userState;
 	const { data } = useFetchUserProfile(userId);
 
 	const [value, setValue] = useState(
@@ -23,7 +25,13 @@ const ApplyModal = ({ open, onClose }: IModalContainerCommonProps): JSX.Element 
 	);
 	const [isPublic, setIsPublic] = useState(false);
 
-	const onClick = useCallback(() => {
+	useEffect(() => {
+		if (data?.userProfile?.bio) {
+			setValue(data?.userProfile?.bio);
+		}
+	}, [data]);
+
+	const onClick = () => {
 		onClose(false);
 		postStudyUser.mutate({
 			id: modal.params,
@@ -31,7 +39,7 @@ const ApplyModal = ({ open, onClose }: IModalContainerCommonProps): JSX.Element 
 				tempBio: value,
 			},
 		});
-	}, []);
+	};
 
 	const onChangeValue = useCallback((evt: ChangeEvent<HTMLTextAreaElement>) => {
 		setValue(evt.target.value);

--- a/src/pages/studyDetail/index.tsx
+++ b/src/pages/studyDetail/index.tsx
@@ -110,7 +110,7 @@ const StudyDetailPage = (): JSX.Element => {
 		if (isHost) {
 			openModal(ModalKeyEnum.StudyCloseModal);
 		} else {
-			openModal(ModalKeyEnum.ApplyModal);
+			openModal(ModalKeyEnum.ApplyModal, studyId);
 		}
 	};
 


### PR DESCRIPTION
원래 API 동작하지 않는 버그를 수정하려고 했는데 해당 버그는 백엔드 이슈로 확인되어서 백엔드 레포에 따로 등록해두었습니다. 
https://github.com/caulipse/caulipse-server/issues/133

본 PR 에서 수정하는 버그는 
스터디 신청 모달이 열릴 때 userProfile 을 조회하여 한줄 소개글 필드에 보여주어야 하는데, userProfile 조회가 정상적으로 되지 않고 있었던 버그와 스터디 참가 신청 API 엔드포인트가 잘못 되어있던 버그를 수정하였습니다. 