### PR TITLE
fix: 스터디 신청하기 API 호출하지 않는 버그 수정

### DIFF
--- a/src/app/modal/ApplyModal.tsx
+++ b/src/app/modal/ApplyModal.tsx
@@ -9,14 +9,15 @@ import { IModalContainerCommonProps } from '@common/modal/types';
 import '@common/modal/common.scss';
 import usePostStudyUser from '@src/hooks/remotes/studyUser/usePostStudyUser';
 import { useAtom } from 'jotai';
-import globalState, { userState as globalUserState } from '@src/state';
+import { userState as globalUserState, modalState as globalModalState } from '@src/state';
 import useFetchUserProfile from '@src/hooks/remotes/user/useFetchUserProfile';
 
 const ApplyModal = ({ open, onClose }: IModalContainerCommonProps): JSX.Element => {
 	const postStudyUser = usePostStudyUser();
-	const [state] = useAtom(globalState);
 	const [userState] = useAtom(globalUserState);
-	const { modal } = state;
+	const [modalState] = useAtom(globalModalState);
+
+	const { params } = modalState;
 	const { userId } = userState;
 	const { data } = useFetchUserProfile(userId);
 
@@ -34,7 +35,7 @@ const ApplyModal = ({ open, onClose }: IModalContainerCommonProps): JSX.Element 
 	const onClick = () => {
 		onClose(false);
 		postStudyUser.mutate({
-			id: modal.params,
+			id: params,
 			data: {
 				tempBio: value,
 			},


### PR DESCRIPTION
스터디 신청하기 API 호출하지 않는 버그 수정
- 원인: state 에서 modalState 를 분리했는데 기존의 state 를 참조하고 있어서 모달 open 시 스터디 Id 를 전달받지 못하고 있었음 