### PR TITLE
fix: 가입하기 클릭 직후 스낵바 호출 삭제

### DIFF
--- a/src/app/signup/signUpFirstStep/index.tsx
+++ b/src/app/signup/signUpFirstStep/index.tsx
@@ -72,7 +72,6 @@ const SignUpFirstStep = ({ email, setEmail, password, setPassword }: SignUpFirst
 	useEffect(() => {
 		if (!isLoading && clientSuccess) {
 			if (data?.data) {
-				openSnackbar('이메일을 보냈습니다.');
 				postSignup.mutate({ email, password });
 			} else {
 				setEmailHelperText(data?.message ?? '이미 존재하는 이메일입니다.');


### PR DESCRIPTION
- 현재 가입하기 클릭 직후 스낵바 및 alert가 두 번 뜹니다.
  - 클릭 직후 뜨는 스낵바
  - 이메일 전송 성공 이후 뜨는 alert
- 이메일 전송 성공 여부와 상관 없이 클릭 직후 뜨는 스낵바가 api 호출 정상 여부를 헷갈리게 할 우려가 있어 삭제했습니다. 