### PR TITLE
스터디 필터 (카테고리, 복수 필터 등) 관련 잔여 이슈 처리

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -61,14 +61,12 @@ const API = {
 	},
 	// 스터디 목록 조회
 	getStudies(orderBy?: string, filter?: IFilterOption, pagination?: IPaginationOption) {
-		// FIXME
-		// 멀티 필터 가능하도록 수정
 		return client.get('/study', {
 			params: {
 				order_by: orderBy,
 				frequency: filter?.frequency?.[0],
-				location: filter?.location?.[0],
-				weekday: filter?.weekday?.[0],
+				location: filter?.location?.join(','),
+				weekday: filter?.weekday?.join(','),
 				categoryCode: filter?.categoryCode?.[0]?.code,
 				limit: pagination?.limit ?? 15,
 				pageNo: pagination?.pageNo ?? 1,

--- a/src/app/shared/utils/category.ts
+++ b/src/app/shared/utils/category.ts
@@ -31,3 +31,10 @@ export const getMainCategoryCode = (subCategoryCode: number): number => {
 	});
 	return mainCategory?.code ?? 100;
 };
+
+export const getMainCategoryCodeFromLabel = (mainCategoryLabel: string): number => {
+	const mainCategory = categories.find((categoryItem) => {
+		return categoryItem.path === mainCategoryLabel;
+	});
+	return mainCategory?.code ?? 0;
+};

--- a/src/app/study/studyList/StudyList.tsx
+++ b/src/app/study/studyList/StudyList.tsx
@@ -14,7 +14,6 @@ const StudyList = (): JSX.Element => {
 
 	const { filterOption, sortOption, paginationOption } = state;
 
-	console.log('sortoption, ', sortOption);
 	const { pageNo } = paginationOption;
 
 	const { data, isLoading } = fetchStudies(sortOption?.value, filterOption, paginationOption);
@@ -58,7 +57,7 @@ const StudyList = (): JSX.Element => {
 					</div>
 				</div>
 			</div>
-			<Container ref={target as unknown as RefObject<HTMLDivElement> | null}>{isLoading && <Loader />}</Container>
+			<Container ref={(target as unknown) as RefObject<HTMLDivElement> | null}>{isLoading && <Loader />}</Container>
 		</div>
 	);
 };


### PR DESCRIPTION
- 메인 > 리스트 페이지 이동 시 상위 카테고리 필터링 로직 적용
- 스터디 요일, 장소 복수 필터 가능하도록 수정