### PR TITLE
fix: 스터디 신청 취소 dummy 데이터 삭제

### DIFF
--- a/src/app/modal/ApproveCancelModal.tsx
+++ b/src/app/modal/ApproveCancelModal.tsx
@@ -7,12 +7,12 @@ import useSnackbar from '@src/hooks/snackbar/useSnackbar';
 import { SnackbarTypeEnum } from '@common/snackbar/types';
 import usePatchStudyUserAccept from '@src/hooks/remotes/studyUser/usePatchStudyUserAccept';
 import { useAtom } from 'jotai';
-import globalState from '@src/state';
+import globalState, { modalState } from '@src/state';
 
 const ApproveCancelModal = ({ open, onClose }: IModalContainerCommonProps): JSX.Element => {
 	const { openSnackbar } = useSnackbar();
-	const [state] = useAtom(globalState);
-	const { modal } = state;
+	const [modal] = useAtom(modalState);
+
 	const patchStudyUserAccept = usePatchStudyUserAccept();
 	const onClick = () => {
 		patchStudyUserAccept.mutate({
@@ -26,8 +26,7 @@ const ApproveCancelModal = ({ open, onClose }: IModalContainerCommonProps): JSX.
 		openSnackbar('스터디 수락을 취소하였습니다', SnackbarTypeEnum.secondary);
 	};
 
-	// TODO
-	const nickname = 'dummy';
+	const nickname = modal.params.username;
 	return (
 		<SimpleModal
 			open={open}

--- a/src/app/modal/ApproveCancelModal.tsx
+++ b/src/app/modal/ApproveCancelModal.tsx
@@ -8,22 +8,41 @@ import { SnackbarTypeEnum } from '@common/snackbar/types';
 import usePatchStudyUserAccept from '@src/hooks/remotes/studyUser/usePatchStudyUserAccept';
 import { useAtom } from 'jotai';
 import globalState, { modalState } from '@src/state';
+import { useQueryClient } from 'react-query';
+import useDeleteStudyUser from '@src/hooks/remotes/studyUser/useDeleteStudyUser';
+import QUERY_KEY from '@src/hooks/remotes';
 
 const ApproveCancelModal = ({ open, onClose }: IModalContainerCommonProps): JSX.Element => {
 	const { openSnackbar } = useSnackbar();
 	const [modal] = useAtom(modalState);
 
-	const patchStudyUserAccept = usePatchStudyUserAccept();
+	const client = useQueryClient();
+
+	const deleteStudyUser = useDeleteStudyUser();
 	const onClick = () => {
-		patchStudyUserAccept.mutate({
-			id: modal.params.studyId,
-			data: {
-				accept: false,
-				userId: modal.params.userId,
-			},
-		});
-		onClose(false);
-		openSnackbar('스터디 수락을 취소하였습니다', SnackbarTypeEnum.secondary);
+		deleteStudyUser.mutate(
+			{ studyId: modal.params.studyId, userId: modal.params.userId },
+			{
+				onSuccess: () => {
+					onClose(false);
+					openSnackbar('스터디 수락 취소하였습니다.', SnackbarTypeEnum.secondary);
+					client.refetchQueries(`${QUERY_KEY.FETCH_STUDY}/${modal.params.studyId}`);
+				},
+				onError: () => {
+					onClose(false);
+					openSnackbar('스터디 신청 취소에 실패하였습니다.', SnackbarTypeEnum.secondary);
+				},
+			}
+		);
+		// patchStudyUserAccept.mutate({
+		// 	id: modal.params.studyId,
+		// 	data: {
+		// 		accept: false,
+		// 		userId: modal.params.userId,
+		// 	},
+		// });
+		// onClose(false);
+		// openSnackbar('스터디 수락을 취소하였습니다', SnackbarTypeEnum.secondary);
 	};
 
 	const nickname = modal.params.username;


### PR DESCRIPTION
- 수락 취소 모달의 더미 데이터를 변경하고, modalState를 참조하도록 변경하였습니다. 
- api 호출이 제대로 되지 않는데 아래 이슈로 등록한 상태입니다.
- https://github.com/caulipse/caulipse-server/issues/163

![image](https://user-images.githubusercontent.com/59302192/172037048-872c125d-010b-48fc-b3d8-b4a90867630a.png)
