### PR TITLE
fix: 모집 마감 데이터 제대로 뜨지 않는 버그 수정

### DIFF
--- a/src/app/modal/StudyCloseModal.tsx
+++ b/src/app/modal/StudyCloseModal.tsx
@@ -10,11 +10,11 @@ import useCloseStudy from '@src/hooks/remotes/study/useCloseStudy';
 
 const StudyCloseModal = ({ open, onClose }: IModalContainerCommonProps): JSX.Element => {
 	const [state] = useAtom(modalState);
-	const { data } = useFetchStudy(state.params);
+	const { data } = useFetchStudy(state.params.id);
 	const closeStudy = useCloseStudy();
 
 	const onClick = () => {
-		closeStudy.mutate(state.params);
+		closeStudy.mutate(state.params.id);
 	};
 
 	return (


### PR DESCRIPTION
모집 마감 모달에서 study 데이터가 제대로 뜨지 않는 버그를 수정했습니다.

![image](https://user-images.githubusercontent.com/59302192/172037553-140b8f4e-c91e-435b-86dd-183fd9e44a04.png)
